### PR TITLE
Fix des problèmes relevés par CoPilot

### DIFF
--- a/src/main/java/com/dreams/zotroul/controller/UtilisateurController.java
+++ b/src/main/java/com/dreams/zotroul/controller/UtilisateurController.java
@@ -42,7 +42,7 @@ public class UtilisateurController {
         }
         if (utilisateurRepository.existsByUsername(utilisateur.getUsername())) {
             return ResponseEntity.status(HttpStatus.CONFLICT)
-                    .body(Map.of("message", "username deja utilise"));
+                    .body(Map.of("message", "username déjà utilisé"));
         }
         utilisateur.setId(null); // sécurité : on ne laisse pas le client imposer un ID
         Utilisateur saved = utilisateurRepository.save(utilisateur);
@@ -58,12 +58,14 @@ public class UtilisateurController {
                     && !utilisateur.getUsername().equals(existing.getUsername())
                     && utilisateurRepository.existsByUsername(utilisateur.getUsername())) {
                 return ResponseEntity.status(HttpStatus.CONFLICT)
-                        .body(Map.of("message", "username deja utilise"));
+                        .body(Map.of("message", "username déjà utilisé"));
             }
             if (utilisateur.getUsername() != null && !utilisateur.getUsername().isBlank()) {
                 existing.setUsername(utilisateur.getUsername());
             }
-            existing.setNumeroTelephone(utilisateur.getNumeroTelephone());
+            if (utilisateur.getNumeroTelephone() != null) {
+                existing.setNumeroTelephone(utilisateur.getNumeroTelephone());
+            }
             Utilisateur saved = utilisateurRepository.save(existing);
             return ResponseEntity.ok(saved);
         }).orElseGet(() -> ResponseEntity.notFound().build());

--- a/src/test/java/com/dreams/zotroul/controller/UtilisateurControllerTest.java
+++ b/src/test/java/com/dreams/zotroul/controller/UtilisateurControllerTest.java
@@ -1,0 +1,92 @@
+package com.dreams.zotroul.controller;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import java.util.Optional;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import com.dreams.zotroul.model.Utilisateur;
+import com.dreams.zotroul.repository.UtilisateurRepository;
+
+@WebMvcTest(UtilisateurController.class)
+class UtilisateurControllerTest {
+
+    @Autowired
+    private MockMvc mvc;
+
+    @MockitoBean
+    private UtilisateurRepository repo;
+
+    @Test
+    void create_retourne_201_avec_utilisateur_valide() throws Exception {
+        Utilisateur saved = utilisateur(10L, "newuser", "0600000000");
+        when(repo.existsByUsername("newuser")).thenReturn(false);
+        when(repo.save(any())).thenReturn(saved);
+
+        mvc.perform(post("/utilisateurs")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"username\":\"newuser\",\"numeroTelephone\":\"0600000000\"}"))
+            .andExpect(status().isCreated())
+            .andExpect(jsonPath("$.id").value(10))
+            .andExpect(jsonPath("$.username").value("newuser"));
+    }
+
+    @Test
+    void create_retourne_400_si_username_absent() throws Exception {
+        mvc.perform(post("/utilisateurs")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"numeroTelephone\":\"0600000000\"}"))
+            .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    void create_retourne_400_si_username_vide() throws Exception {
+        mvc.perform(post("/utilisateurs")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"username\":\"\"}"))
+            .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    void create_retourne_409_si_username_duplique() throws Exception {
+        when(repo.existsByUsername("alice")).thenReturn(true);
+
+        mvc.perform(post("/utilisateurs")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"username\":\"alice\"}"))
+            .andExpect(status().isConflict());
+    }
+
+    @Test
+    void update_preserve_numeroTelephone_si_non_fourni() throws Exception {
+        Utilisateur existing = utilisateur(1L, "alice", "0123456789");
+        when(repo.findById(1L)).thenReturn(Optional.of(existing));
+        when(repo.existsByUsername("alice-updated")).thenReturn(false);
+        // Retourne l'entité telle qu'elle est passée à save() pour vérifier son état réel
+        when(repo.save(any())).thenAnswer(inv -> inv.getArgument(0));
+
+        mvc.perform(put("/utilisateurs/1")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"username\":\"alice-updated\"}"))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.username").value("alice-updated"))
+            .andExpect(jsonPath("$.numeroTelephone").value("0123456789"));
+    }
+
+    private Utilisateur utilisateur(Long id, String username, String tel) {
+        Utilisateur u = new Utilisateur();
+        u.setId(id);
+        u.setUsername(username);
+        u.setNumeroTelephone(tel);
+        return u;
+    }
+}


### PR DESCRIPTION
<p style="white-space: pre-wrap; margin-top: 0px; margin-bottom: 0.2em; color: rgb(32, 32, 32); font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; background-color: rgb(250, 250, 253); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">Voici un résumé de ce qui a été fait :</p><p style="white-space: pre-wrap; margin-top: 0.1em; margin-bottom: 0.2em; color: rgb(32, 32, 32); font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; background-color: rgb(250, 250, 253); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><strong>Bug corrigé</strong> — <a href="vscode-webview://0ran3hcrf2s28ftgvpsrrfat3u69mi48tumfh7a4rt5d1uheh6uh/src/main/java/com/dreams/zotroul/controller/UtilisateurController.java#L66" target="_blank" rel="noopener noreferrer" style="color: rgb(0, 105, 204); text-decoration: rgb(0, 105, 204);">UtilisateurController.java:66</a> : le <code style="font-family: monospace; color: rgb(96, 96, 96); background-color: rgb(236, 236, 236); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">PUT</code> écrasait toujours <code style="font-family: monospace; color: rgb(96, 96, 96); background-color: rgb(236, 236, 236); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">numeroTelephone</code> (même avec <code style="font-family: monospace; color: rgb(96, 96, 96); background-color: rgb(236, 236, 236); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">null</code>). Désormais, on ne le met à jour que s'il est explicitement fourni dans la requête.</p><p style="white-space: pre-wrap; margin-top: 0.1em; margin-bottom: 0.2em; color: rgb(32, 32, 32); font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; background-color: rgb(250, 250, 253); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><strong>Tests ajoutés</strong> — <a href="vscode-webview://0ran3hcrf2s28ftgvpsrrfat3u69mi48tumfh7a4rt5d1uheh6uh/src/test/java/com/dreams/zotroul/controller/UtilisateurControllerTest.java" target="_blank" rel="noopener noreferrer" style="color: rgb(0, 105, 204); text-decoration: rgb(0, 105, 204);">UtilisateurControllerTest.java</a> avec <code style="font-family: monospace; color: rgb(96, 96, 96); background-color: rgb(236, 236, 236); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">@WebMvcTest</code> (couche HTTP uniquement, sans base de données) :</p>
Test | Ce qu'il vérifie
-- | --
create_retourne_201_avec_utilisateur_valide | POST valide → 201 + corps correct
create_retourne_400_si_username_absent | Pas de username → 400
create_retourne_400_si_username_vide | Username "" → 400
create_retourne_409_si_username_duplique | Username existant → 409
update_preserve_numeroTelephone_si_non_fourni | PUT sans téléphone → téléphone préservé

<p style="white-space: pre-wrap; margin-top: 0.1em; margin-bottom: 0.2em; color: rgb(32, 32, 32); font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; background-color: rgb(250, 250, 253); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">Note : en Spring Boot 4.x, <code style="font-family: monospace; color: rgb(96, 96, 96); background-color: rgb(236, 236, 236); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">@WebMvcTest</code> a déménagé vers <code style="font-family: monospace; color: rgb(96, 96, 96); background-color: rgb(236, 236, 236); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">org.springframework.boot.webmvc.test.autoconfigure</code> (ancien package <code style="font-family: monospace; color: rgb(96, 96, 96); background-color: rgb(236, 236, 236); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">org.springframework.boot.test.autoconfigure.web.servlet</code> supprimé).</p>Voici un résumé de ce qui a été fait :

Bug corrigé — [UtilisateurController.java:66](vscode-webview://0ran3hcrf2s28ftgvpsrrfat3u69mi48tumfh7a4rt5d1uheh6uh/src/main/java/com/dreams/zotroul/controller/UtilisateurController.java#L66) : le PUT écrasait toujours numeroTelephone (même avec null). Désormais, on ne le met à jour que s'il est explicitement fourni dans la requête.

Tests ajoutés — [UtilisateurControllerTest.java](vscode-webview://0ran3hcrf2s28ftgvpsrrfat3u69mi48tumfh7a4rt5d1uheh6uh/src/test/java/com/dreams/zotroul/controller/UtilisateurControllerTest.java) avec @WebMvcTest (couche HTTP uniquement, sans base de données) :


Test | Ce qu'il vérifie
-- | --
create_retourne_201_avec_utilisateur_valide | POST valide → 201 + corps correct
create_retourne_400_si_username_absent | Pas de username → 400
create_retourne_400_si_username_vide | Username "" → 400
create_retourne_409_si_username_duplique | Username existant → 409
update_preserve_numeroTelephone_si_non_fourni | PUT sans téléphone → téléphone préservé


Note : en Spring Boot 4.x, @WebMvcTest a déménagé vers org.springframework.boot.webmvc.test.autoconfigure (ancien package org.springframework.boot.test.autoconfigure.web.servlet supprimé).